### PR TITLE
Add support for composite PKs

### DIFF
--- a/ts/entities.ts
+++ b/ts/entities.ts
@@ -39,16 +39,18 @@ export function collectionToEntitySchema(collectionDefinition : CollectionDefini
             continue
         }
 
-        const columsOptions : EntitySchemaColumnOptions = fieldToEntitySchemaColumn(fieldDefinition, {
+        const columnOptions : EntitySchemaColumnOptions = fieldToEntitySchemaColumn(fieldDefinition, {
             collectionName: entitySchemaOptions.name,
             fieldName,
         })
-        
-        if (collectionDefinition.pkIndex === fieldName) {
-            columsOptions.primary = true
+
+        if (collectionDefinition.pkIndex instanceof Array
+            ? collectionDefinition.pkIndex.includes(fieldName)
+            : collectionDefinition.pkIndex === fieldName) {
+            columnOptions.primary = true
         }
 
-        entitySchemaOptions.columns[fieldName] = columsOptions
+        entitySchemaOptions.columns[fieldName] = columnOptions
     }
     for (const relationship of collectionDefinition.relationships || []) {
         if (isChildOfRelationship(relationship)) {


### PR DESCRIPTION
- just needed to set `primary` on the column opts for both fields involved in the key, which requires checking of the generated `pkIndex` type (array if composite)
- relevant typeorm docs: https://typeorm.io/#/entities/primary-columns